### PR TITLE
Added support for closing Image modal in twitter card with back button

### DIFF
--- a/src/Twitter/ImageGallery.tsx
+++ b/src/Twitter/ImageGallery.tsx
@@ -150,6 +150,12 @@ export const ImageGallery = (props: PropsType) => {
       <Modal
         animationType={"slide"}
         visible={isModalVisible}
+        onRequestClose={() => {
+          setModalState({
+            isModalVisible: false,
+            itemPressed: modalState.itemPressed,
+          });
+        }}
         // no pagesheet type cause of https://github.com/facebook/react-native/issues/26892
       >
         <View


### PR DESCRIPTION
Currently image modal which gets opened when pressed on an image in twitter card, doesn't close on pressing back button.
The only way to close that is by the cross icon on the top right corner of the modal.

This PR solves that.