### PR TITLE
Improve image visibility

### DIFF
--- a/src/Twitter/ImageGallery.tsx
+++ b/src/Twitter/ImageGallery.tsx
@@ -77,7 +77,7 @@ export const ImageGallery = (props: PropsType) => {
                 flex: 1,
                 width: "100%",
               }}
-              resizeMode={"cover"}
+              resizeMode={"stretch"}
             />
           </TouchableOpacity>
           {medias[3] ? (
@@ -96,7 +96,7 @@ export const ImageGallery = (props: PropsType) => {
                     flex: 1,
                     width: "100%",
                   }}
-                  resizeMode={"cover"}
+                  resizeMode={"stretch"}
                 />
               </TouchableOpacity>
             </>
@@ -119,7 +119,7 @@ export const ImageGallery = (props: PropsType) => {
                     flex: 1,
                     width: "100%",
                   }}
-                  resizeMode={"cover"}
+                  resizeMode={"stretch"}
                 />
               </TouchableOpacity>
               {medias[2] ? (
@@ -138,7 +138,7 @@ export const ImageGallery = (props: PropsType) => {
                         flex: 1,
                         width: "100%",
                       }}
-                      resizeMode={"cover"}
+                      resizeMode={"stretch"}
                     />
                   </TouchableOpacity>
                 </>
@@ -187,6 +187,7 @@ export const ImageGallery = (props: PropsType) => {
                     flex: 1,
                     aspectRatio: element.aspectRatio,
                   }}
+                  resizeMode={"stretch"}
                 />
               ))}
             </ScrollView>


### PR DESCRIPTION
# Current Implementation : 
![image](https://user-images.githubusercontent.com/17861054/94364520-78427a00-00e7-11eb-9ee6-05f385b03b02.png)
## When clicking the image in modal, it looks like this : 
![image](https://user-images.githubusercontent.com/17861054/94364522-7b3d6a80-00e7-11eb-9a27-ecf2b7b00192.png)

## After this PR : 
![image](https://user-images.githubusercontent.com/17861054/94364526-86909600-00e7-11eb-9d74-c34823492e8a.png)
## When clicking the image in modal, it looks like this : 
![image](https://user-images.githubusercontent.com/17861054/94364529-8db7a400-00e7-11eb-803a-3765a97e7647.png)

