### PR TITLE
Added text decoding for html entities in twitter card

### DIFF
--- a/src/Twitter/api.ts
+++ b/src/Twitter/api.ts
@@ -1,6 +1,8 @@
 import { TwitterPostApiResponse, UserMention } from "./typings";
 import { generateFetchRequestHeaders } from "./generateTwitterHeaders";
+import { Html5Entities } from "html-entities";
 
+const entities = new Html5Entities();
 export const getPostData = async (
   postId: string,
   consumerKey: string,
@@ -33,7 +35,7 @@ export const adapter = (data: TwitterPostApiResponse): ITwitterPost => {
     isPosterVerified: data.user.verified,
     retweetNumber: data.retweet_count,
     likeNumber: data.favorite_count,
-    textContent: data.full_text.replace("&amp;", "&"),
+    textContent: entities.decode(data.full_text),
     isQuote: data?.is_quote_status,
     urlList: data?.entities?.urls,
     hashtagList: data?.entities?.hashtags,


### PR DESCRIPTION
## Right now the html entities are rendered encoded.
## Current situation : 
![image](https://user-images.githubusercontent.com/17861054/95016634-d2a48300-0671-11eb-9080-e9b45adbb7c6.png)


## After this PR : 

![image](https://user-images.githubusercontent.com/17861054/95016627-c8828480-0671-11eb-95ac-ad6ee0adddc2.png)

