### PR TITLE
always use tweet small image size to compute aspect ratio

### DIFF
--- a/src/Twitter/api.ts
+++ b/src/Twitter/api.ts
@@ -53,21 +53,12 @@ export const adapter = (data: TwitterPostApiResponse): ITwitterPost => {
         };
       }
       if (element?.type === "photo") {
-        if (data.extended_entities?.media?.length === 1) {
-          return {
-            type: element?.type,
-            aspectRatio: element.sizes.thumb.w / element.sizes.thumb.h,
-            url: element.media_url_https,
-            twitterShortlink: element?.url,
-          };
-        } else {
-          return {
-            type: element?.type,
-            aspectRatio: element.sizes.small.w / element.sizes.small.h,
-            url: element.media_url_https,
-            twitterShortlink: element?.url,
-          };
-        }
+        return {
+          type: element?.type,
+          aspectRatio: element.sizes.small.w / element.sizes.small.h,
+          url: element.media_url_https,
+          twitterShortlink: element?.url,
+        };
       }
       return null;
     }),


### PR DESCRIPTION
using thumb can drive to unexpected image ratio (see official doc example https://developer.twitter.com/en/docs/twitter-api/v1/data-dictionary/overview/extended-entities-object)