### PR TITLE
Avoid Array.flat method

### DIFF
--- a/src/Twitter/TwitterText.tsx
+++ b/src/Twitter/TwitterText.tsx
@@ -61,7 +61,7 @@ const transformTextToAddColors = (
       }
     }
   });
-  return copy.flat(1);
+  return [].concat.apply([], copy);
 };
 
 export const TwitterText = (props: PropsType) => {


### PR DESCRIPTION
Because it's not supported in iOS 11